### PR TITLE
feat: async mode

### DIFF
--- a/src/waylay/sdk/api/client.py
+++ b/src/waylay/sdk/api/client.py
@@ -44,7 +44,7 @@ class ApiClient(WithSerializationSupport):
         if http_options:
             self.set_options(http_options)
 
-    def set_options(self, http_options: HttpClientOptions | AsyncClient):
+    def set_options(self, http_options: HttpClientOptions | AsyncClient | None):
         """Update http options on not open client."""
         if not self.is_closed:
             raise AttributeError("Cannot set options on open client.")

--- a/src/waylay/sdk/api/serialization.py
+++ b/src/waylay/sdk/api/serialization.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any, Mapping, Optional, cast, AsyncIterable, get_origin
 from io import BufferedReader
 from abc import abstractmethod
+import warnings
 
 from dateutil.parser import parse
 from pydantic import TypeAdapter, ValidationError
@@ -99,17 +100,24 @@ class WithSerializationSupport:
         self,
         response: Response,
         response_types_map=None,
-        select_path: str = ''
+        select_path: str = '',
+        stream: bool = False
     ) -> Any:
         """Deserialize response into a model object.
 
         :param response_data: Response object to be deserialized.
         :param response_types_map: dict of response types.
         :param select_path: json path into the json payload.
-        :return: ApiResponse
+        :return: The response model
         """
+        if stream:
+            warnings.warn(
+                'Using `stream=True` is currently only supported with `raw_response=True`.'
+            )
+            return response
         status_code = response.status_code
         status_code_key = str(status_code)
+        response_types_map = response_types_map or {}
         response_type = response_types_map.get(status_code_key, None)
         if (
             not response_type


### PR DESCRIPTION
* have a `stream` argument in response_deserialize to prepare
  handling streaming models (e.g. events). Currently warns
  and send native Response
* let `WithApiClient` be invokable to update http options
```
with wc.my_service.my_api({ 'timeout': 50, 'auth': None}) as api:
    dog_fido = api.get('fido')

```