### PR TITLE
chore: improve request serialization

### DIFF
--- a/test/unit/api/__init__.py
+++ b/test/unit/api/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the api client."""

--- a/test/unit/api/__snapshots__/api_client_test.ambr
+++ b/test/unit/api/__snapshots__/api_client_test.ambr
@@ -816,6 +816,31 @@
     None,
   )
 # ---
+# name: test_serialize_and_call[binary_async_iterable]
+  dict({
+    'extensions': dict({
+      'timeout': dict({
+        'connect': 5.0,
+        'pool': 5.0,
+        'read': 5.0,
+        'write': 5.0,
+      }),
+    }),
+    'headers': Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    'method': 'POST',
+    'stream': AsyncIteratorByteStream(
+      CHUNK_SIZE=65536,
+    ),
+    'url': URL('https://api-example.io/service/v1/bar/foo'),
+  })
+# ---
+# name: test_serialize_and_call[binary_async_iterable].1
+  tuple(
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    b'itersomebinarycontent',
+  )
+# ---
 # name: test_serialize_and_call[binary_body]
   dict({
     '_content': b'..some binary content..',
@@ -836,15 +861,84 @@
 # ---
 # name: test_serialize_and_call[binary_body].1
   tuple(
-    list([
-      <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '23'}),
-        b'..some binary content..',
-      ),
-    ]),
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '23'}),
+    b'..some binary content..',
+  )
+# ---
+# name: test_serialize_and_call[binary_io]
+  dict({
+    'extensions': dict({
+      'timeout': dict({
+        'connect': 5.0,
+        'pool': 5.0,
+        'read': 5.0,
+        'write': 5.0,
+      }),
+    }),
+    'headers': Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    'method': 'POST',
+    'stream': AsyncIteratorByteStream(
+      CHUNK_SIZE=65536,
+    ),
+    'url': URL('https://api-example.io/service/v1/bar/foo'),
+  })
+# ---
+# name: test_serialize_and_call[binary_io].1
+  tuple(
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    b'some binary content',
+  )
+# ---
+# name: test_serialize_and_call[binary_io_buffer]
+  dict({
+    'extensions': dict({
+      'timeout': dict({
+        'connect': 5.0,
+        'pool': 5.0,
+        'read': 5.0,
+        'write': 5.0,
+      }),
+    }),
+    'headers': Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    'method': 'POST',
+    'stream': AsyncIteratorByteStream(
+      CHUNK_SIZE=65536,
+    ),
+    'url': URL('https://api-example.io/service/v1/bar/foo'),
+  })
+# ---
+# name: test_serialize_and_call[binary_io_buffer].1
+  tuple(
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    b'"""Unit tests for the api client."""\n',
+  )
+# ---
+# name: test_serialize_and_call[binary_iterable]
+  dict({
+    'extensions': dict({
+      'timeout': dict({
+        'connect': 5.0,
+        'pool': 5.0,
+        'read': 5.0,
+        'write': 5.0,
+      }),
+    }),
+    'headers': Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    'method': 'POST',
+    'stream': AsyncIteratorByteStream(
+      CHUNK_SIZE=65536,
+    ),
+    'url': URL('https://api-example.io/service/v1/bar/foo'),
+  })
+# ---
+# name: test_serialize_and_call[binary_iterable].1
+  tuple(
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'transfer-encoding': 'chunked'}),
+    b'somebinarycontent',
   )
 # ---
 # name: test_serialize_and_call[data_and_files]
@@ -883,15 +977,9 @@
 # ---
 # name: test_serialize_and_call[data_and_files].1
   tuple(
-    list([
-      <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '226', 'content-type': 'multipart/form-data; boundary=---boundary---'}),
-        b'-----boundary---\r\nContent-Disposition: form-data; name="key"\r\n\r\nvalue\r\n-----boundary---\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<binary>\r\n-----boundary-----\r\n',
-      ),
-    ]),
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '226', 'content-type': 'multipart/form-data; boundary=---boundary---'}),
+    b'-----boundary---\r\nContent-Disposition: form-data; name="key"\r\n\r\nvalue\r\n-----boundary---\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<binary>\r\n-----boundary-----\r\n',
   )
 # ---
 # name: test_serialize_and_call[files]
@@ -935,15 +1023,9 @@
 # ---
 # name: test_serialize_and_call[files].1
   tuple(
-    list([
-      <Request('POST', 'https://api-example.io/service/v1/cruz/?key1=15')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '328', 'content-type': 'multipart/form-data; boundary=---boundary---'}),
-        b'-----boundary---\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<... binary content ...>\r\n-----boundary---\r\nContent-Disposition: form-data; name="file2"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<... other binary content ...>\r\n-----boundary-----\r\n',
-      ),
-    ]),
+    <Request('POST', 'https://api-example.io/service/v1/cruz/?key1=15')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '328', 'content-type': 'multipart/form-data; boundary=---boundary---'}),
+    b'-----boundary---\r\nContent-Disposition: form-data; name="file1"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<... binary content ...>\r\n-----boundary---\r\nContent-Disposition: form-data; name="file2"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n<... other binary content ...>\r\n-----boundary-----\r\n',
   )
 # ---
 # name: test_serialize_and_call[form]
@@ -966,15 +1048,9 @@
 # ---
 # name: test_serialize_and_call[form].1
   tuple(
-    list([
-      <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '9', 'content-type': 'application/x-www-form-urlencoded'}),
-        b'key=value',
-      ),
-    ]),
+    <Request('POST', 'https://api-example.io/service/v1/bar/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '9', 'content-type': 'application/x-www-form-urlencoded'}),
+    b'key=value',
   )
 # ---
 # name: test_serialize_and_call[params_and_body]
@@ -997,15 +1073,9 @@
 # ---
 # name: test_serialize_and_call[params_and_body].1
   tuple(
-    list([
-      <Request('PATCH', 'https://api-example.io/service/v1/A/bar/%7Bmissing_param%7D')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'x-my-header': 'header_value', 'content-length': '119', 'content-type': 'application/json'}),
-        b'{"array_key": ["val1", "val2"], "tuple_key": ["val3", 123, {"key": "value"}, null], "timestamp": "1999-09-28T12:30:59"}',
-      ),
-    ]),
+    <Request('PATCH', 'https://api-example.io/service/v1/A/bar/%7Bmissing_param%7D')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'x-my-header': 'header_value', 'content-length': '119', 'content-type': 'application/json'}),
+    b'{"array_key": ["val1", "val2"], "tuple_key": ["val3", 123, {"key": "value"}, null], "timestamp": "1999-09-28T12:30:59"}',
   )
 # ---
 # name: test_serialize_and_call[path_and_query_params]
@@ -1028,15 +1098,9 @@
 # ---
 # name: test_serialize_and_call[path_and_query_params].1
   tuple(
-    list([
-      <Request('GET', 'https://api-example.io/service/v1/A/foo/B?key1=value1&key2=value2')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'x-my-header': 'header_value'}),
-        b'',
-      ),
-    ]),
+    <Request('GET', 'https://api-example.io/service/v1/A/foo/B?key1=value1&key2=value2')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'x-my-header': 'header_value'}),
+    b'',
   )
 # ---
 # name: test_serialize_and_call[pet_body]
@@ -1059,15 +1123,9 @@
 # ---
 # name: test_serialize_and_call[pet_body].1
   tuple(
-    list([
-      <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '95', 'content-type': 'application/json'}),
-        b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
-      ),
-    ]),
+    <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '95', 'content-type': 'application/json'}),
+    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
   )
 # ---
 # name: test_serialize_and_call[pet_dict_body]
@@ -1090,15 +1148,9 @@
 # ---
 # name: test_serialize_and_call[pet_dict_body].1
   tuple(
-    list([
-      <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '95', 'content-type': 'application/json'}),
-        b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
-      ),
-    ]),
+    <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '95', 'content-type': 'application/json'}),
+    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
   )
 # ---
 # name: test_serialize_and_call[pet_json_body]
@@ -1121,14 +1173,8 @@
 # ---
 # name: test_serialize_and_call[pet_json_body].1
   tuple(
-    list([
-      <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
-    ]),
-    list([
-      tuple(
-        Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '105', 'content-type': 'application/json'}),
-        b'"{\\"name\\":\\"Lord Biscuit, Master of Naps\\",\\"owner\\":{\\"id\\":123,\\"name\\":\\"Simon\\"},\\"tag\\":\\"doggo\\"}"',
-      ),
-    ]),
+    <Request('PUT', 'https://api-example.io/service/v1/C/foo')>,
+    Headers({'host': 'api-example.io', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'waylay-sdk/python/0.0.3', 'content-length': '105', 'content-type': 'application/json'}),
+    b'"{\\"name\\":\\"Lord Biscuit, Master of Naps\\",\\"owner\\":{\\"id\\":123,\\"name\\":\\"Simon\\"},\\"tag\\":\\"doggo\\"}"',
   )
 # ---


### PR DESCRIPTION
* serialize data, json and params with additional option `exclude_none: True`
* make serialization arguments configuration on api client (`serialization_args`)
* remove unused `build_params` and `convert_body` methods
* adapt `content` objects for async case:
  * convert `Iterable` or anything with a `read` method to `AsyncIterable` (when not supported otherwise)
* improve coverage