### PR TITLE
feat: support `response_type` in request and serialize

### DIFF
--- a/test/unit/api/api_client_test.py
+++ b/test/unit/api/api_client_test.py
@@ -654,7 +654,7 @@ def test_deserialize(
     response_kwargs = _retrieve_fixture_values(request, response_kwargs)
     response = Response(**response_kwargs)
     deserialized = waylay_api_client.deserialize(
-        response, response_type_map, select_path
+        response, response_type_map=response_type_map, select_path=select_path
     )
     assert (
         response.content,
@@ -751,7 +751,9 @@ def test_deserialize_error_responses(
     """Test REST param deserializer when error response."""
     response_kwargs = _retrieve_fixture_values(request, response_kwargs)
     with pytest.raises(ApiError) as excinfo:
-        waylay_api_client.deserialize(Response(**response_kwargs), response_type_map)
+        waylay_api_client.deserialize(
+            Response(**response_kwargs), response_type_map=response_type_map
+        )
     assert (
         str(excinfo.value),
         type(excinfo.value.data).__name__,
@@ -769,7 +771,7 @@ async def test_deserialize_partially_fetched_error_stream(
     )
     await resp.aiter_raw(chunk_size=1).__anext__()
     with pytest.raises(ApiError) as excinfo:
-        waylay_api_client.deserialize(resp, {})
+        waylay_api_client.deserialize(resp, response_type_map={})
     assert (
         str(excinfo.value),
         type(excinfo.value.data).__name__,

--- a/test/unit/context_mgmt_test.py
+++ b/test/unit/context_mgmt_test.py
@@ -25,7 +25,9 @@ class MyService(WaylayService):
         resp = await self.api_client.send(req)
         if with_http_info:
             return resp
-        return self.api_client.deserialize(resp, {"*": Model}, select_path)
+        return self.api_client.deserialize(
+            resp, response_type_map={"*": Model}, select_path=select_path
+        )
 
 
 class MyTool(WaylayTool):


### PR DESCRIPTION
To be used as response type for `2XX` responses.
(idem as currently in generator code).

Breaking change: call args  of `deserialize` (after first) have been made keyword-only.


This allows to say
```
status_resp = await waylay.api_client.request('GET', '/registry/v2', response_type=dict)
```

I propose to adapt the generator to directly use this argument, and also to support `response_type_map`: e.g. in cases the error responses need customisation:
```
status_resp = await waylay.api_client.request('GET', '/registry/v2', response_type_map={'*': dict})
```