### PR TITLE
fix: set missing fields to none when creating model without validation

### DIFF
--- a/src/waylay/sdk/services/gateway.py
+++ b/src/waylay/sdk/services/gateway.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, TypeVar, overload
+from typing import Any, Dict, Literal, TypeVar, Union, overload
 from pydantic import ConfigDict
+from typing_extensions import TypeAlias
 
 from waylay.sdk.api.client import ApiClient
 from waylay.sdk.api.http import HeaderTypes, QueryParamTypes, Response
@@ -145,7 +146,7 @@ class AboutApi(WithApiClient):
         )
 
 
-class GatewayResponse(WaylayBaseModel):
+class GatewayResponseStatus(WaylayBaseModel):
     """Gateway status response."""
 
     name: str
@@ -154,7 +155,9 @@ class GatewayResponse(WaylayBaseModel):
 
     model_config = ConfigDict(
         populate_by_name=True,
-        validate_assignment=True,
         protected_namespaces=(),
         extra="allow",
     )
+
+
+GatewayResponse: TypeAlias = Union[GatewayResponseStatus, str]

--- a/test/unit/__snapshots__/iter_event_stream_test.ambr
+++ b/test/unit/__snapshots__/iter_event_stream_test.ambr
@@ -28,13 +28,13 @@
   })
 # ---
 # name: test_iter_event_stream[model_events]
-  EventModel(event='started', data=EventData(type='build'))
+  EventModel(event='started', data=EventData(type='build', returnvalue=None))
 # ---
 # name: test_iter_event_stream[model_events].1
   EventModel(event='completed', data=EventData(type='build', returnvalue=0))
 # ---
 # name: test_iter_event_stream[model_events_select_path]
-  EventData(type='build')
+  EventData(type='build', returnvalue=None)
 # ---
 # name: test_iter_event_stream[model_events_select_path].1
   EventData(type='build', returnvalue=0)

--- a/test/unit/api/__snapshots__/api_client_test.ambr
+++ b/test/unit/api/__snapshots__/api_client_test.ambr
@@ -561,7 +561,7 @@
     }),
     None,
     'PetList',
-    PetList(pets=[Pet(name=111, owner=PetOwner(id='invalidId', name='Simon'), tag=None), Pet(name='Chop', tag=None)]),
+    PetList(pets=[Pet(name=111, owner=PetOwner(id='invalidId', name='Simon'), tag=None), Pet(name='Chop', tag=None, owner=None)]),
   )
 # ---
 # name: test_deserialize[json_model_invalid_submodule_list]
@@ -575,7 +575,7 @@
     'list',
     list([
       Pet(name=111, owner=PetOwner(id='invalidId', name='Simon'), tag=None),
-      Pet(name='Chop', tag=None),
+      Pet(name='Chop', tag=None, owner=None),
     ]),
   )
 # ---
@@ -588,7 +588,7 @@
     }),
     None,
     'Pet',
-    Pet(owner=PetOwner(id=456, name='Simontis'), tag=None),
+    Pet(owner=PetOwner(id=456, name='Simontis'), tag=None, name=None),
   )
 # ---
 # name: test_deserialize[json_model_missing_submodel_field]
@@ -600,7 +600,7 @@
     }),
     None,
     'Pet',
-    Pet(name='Chop', tag=None),
+    Pet(name='Chop', tag=None, owner=None),
   )
 # ---
 # name: test_deserialize[json_number]

--- a/test/unit/api/example/pet_model.py
+++ b/test/unit/api/example/pet_model.py
@@ -15,7 +15,6 @@ class PetList(BaseModel):
 
     model_config = {
         "populate_by_name": True,
-        "validate_assignment": True,
         "protected_namespaces": (),
     }
 
@@ -29,7 +28,6 @@ class Pet(BaseModel):
 
     model_config = {
         "populate_by_name": True,
-        "validate_assignment": True,
         "protected_namespaces": (),
     }
 
@@ -42,7 +40,6 @@ class PetOwner(BaseModel):
 
     model_config = {
         "populate_by_name": True,
-        "validate_assignment": True,
         "protected_namespaces": (),
     }
 


### PR DESCRIPTION
This avoids some `keyError` logs for missing fields originating from internal pydantic validators