### PR TITLE
Fix/correct update deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test-integration: install
 test-integration-coverage-report: install ### generate html coverage report for the integration tests
 	${PYTEST_CMD} --cov-report html:cov_report/integration --cov=src test/integration
 
-test: format test-unit ### perform all quality checks and tests, except for integration tests
+test: format code-qa test-unit ### perform all quality checks and tests, except for integration tests
 
 
 ci-install:

--- a/src/waylay/sdk/api/_models.py
+++ b/src/waylay/sdk/api/_models.py
@@ -193,10 +193,10 @@ class _Model(BaseModel):
 Primitive: TypeAlias = Union[
     str, bool, int, float, Decimal, bytes, datetime, date, object, None
 ]
-Model: TypeAlias = TypeAliasType(  # type: ignore[valid-type]  #(https://github.com/python/mypy/issues/16614)
+Model: TypeAlias = TypeAliasType(  # type: ignore[misc]  #(https://github.com/python/mypy/issues/16614)
     "Model",
     Annotated[
-        Union[List["Model"], "_Model", Primitive],  # type: ignore[misc,possible cyclic definition]
+        Union[List["Model"], "_Model", Primitive], # type: ignore[misc]
         "A basic model that acts like a `simpleNamespace` "
         "or a collection over such models.",
     ],


### PR DESCRIPTION
Upgrades in #64 changed the error categories that need to be excluded for the `Model` typealias