### PR TITLE
chore: upgrade httpx to 0.28.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ exec-freeze-deps:
 CONDA_INIT=source $$(conda info --base)/etc/profile.d/conda.sh
 
 
-PYTHON_VERSION?=3.9
+PYTHON_VERSION?=3.11
 PYTHON_VERSIONS=3.9 3.10 3.11 3.12
 
 freeze-deps-conda:

--- a/requirements/requirements.3.11.txt
+++ b/requirements/requirements.3.11.txt
@@ -1,16 +1,16 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@108a0dcd6fa506d2494970d6a762b1d990e12601#egg=waylay_sdk_core
-PyJWT==2.10.0
+# -e git+https://github.com/waylayio/waylay-py-core.git@02249801f16a68fc3719b908bbc9f4a4a1b2901f#egg=waylay_sdk_core
+PyJWT==2.10.1
 annotated-types==0.7.0
 anyio==4.6.2.post1
 appdirs==1.4.4
 certifi>=2024.8.30
 h11==0.14.0
 httpcore==1.0.7
-httpx==0.27.2
+httpx==0.28.0
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11
-pydantic==2.10.1
+pydantic==2.10.2
 pydantic_core==2.27.1
 python-dateutil==2.9.0.post0
 six==1.16.0

--- a/requirements/requirements.build.3.11.txt
+++ b/requirements/requirements.build.3.11.txt
@@ -1,6 +1,6 @@
 build==1.2.2.post1
 packaging==24.2
-pip==24.2
+pip==24.3.1
 pyproject_hooks==1.2.0
 setuptools==75.6.0
 wheel==0.45.1

--- a/requirements/requirements.dev.3.11.txt
+++ b/requirements/requirements.dev.3.11.txt
@@ -1,4 +1,4 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@108a0dcd6fa506d2494970d6a762b1d990e12601#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@02249801f16a68fc3719b908bbc9f4a4a1b2901f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 PyYAML==6.0.2
 cfgv==3.4.0
 click==8.1.7


### PR DESCRIPTION
This breaks code, see https://waylay.atlassian.net/browse/WPPM-2399

Note that in development mode, pytest-httpx downgrades httpx again to 0.27.0