### PR TITLE
chore: upgrade depenencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ PYTHON_VERSION?=3.11
 PYTHON_VERSIONS=3.9 3.10 3.11 3.12 3.13
 
 freeze-deps-conda:
-	@-conda env remove -n waylay-sdk-${PYTHON_VERSION}
+	@-conda env remove -y -n waylay-sdk-${PYTHON_VERSION}
 	@conda create -y -n waylay-sdk-${PYTHON_VERSION} python=${PYTHON_VERSION} 
 	@${CONDA_INIT} && conda activate waylay-sdk-${PYTHON_VERSION} && make exec-freeze-deps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 authors = [{name = "Waylay", email = "info@waylay.io"}]
 license={file = "LICENSE.txt"}
 dependencies = [
-    "httpx == 0.27.*",
+    "httpx",
     "appdirs",
     "pyjwt",
     "python_dateutil",

--- a/requirements/requirements.3.10.txt
+++ b/requirements/requirements.3.10.txt
@@ -1,4 +1,4 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_core
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_core
 annotated-types==0.7.0
 anyio==4.9.0
 appdirs==1.4.4
@@ -6,7 +6,7 @@ certifi>=2025.4.26
 exceptiongroup==1.3.0
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11

--- a/requirements/requirements.3.11.txt
+++ b/requirements/requirements.3.11.txt
@@ -1,11 +1,11 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_core
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_core
 annotated-types==0.7.0
 anyio==4.9.0
 appdirs==1.4.4
 certifi>=2025.4.26
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11

--- a/requirements/requirements.3.12.txt
+++ b/requirements/requirements.3.12.txt
@@ -1,11 +1,11 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_core
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_core
 annotated-types==0.7.0
 anyio==4.9.0
 appdirs==1.4.4
 certifi>=2025.4.26
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11

--- a/requirements/requirements.3.13.txt
+++ b/requirements/requirements.3.13.txt
@@ -1,11 +1,11 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_core
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_core
 annotated-types==0.7.0
 anyio==4.9.0
 appdirs==1.4.4
 certifi>=2025.4.26
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11

--- a/requirements/requirements.3.9.txt
+++ b/requirements/requirements.3.9.txt
@@ -1,4 +1,4 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_core
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_core
 annotated-types==0.7.0
 anyio==4.9.0
 appdirs==1.4.4
@@ -7,7 +7,7 @@ eval-type-backport==0.1.3
 exceptiongroup==1.3.0
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.27.2
+httpx==0.28.1
 idna==3.10
 jsonpath-ng==1.7.0
 ply==3.11

--- a/requirements/requirements.dev.3.10.txt
+++ b/requirements/requirements.dev.3.10.txt
@@ -1,6 +1,6 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 cfgv==3.4.0
-coverage==7.8.2
+coverage==7.9.0
 distlib==0.3.9
 filelock==3.18.0
 identify==2.6.12
@@ -14,8 +14,8 @@ pluggy==1.6.0
 pre_commit==4.2.0
 Pygments==2.19.1
 pytest-asyncio==1.0.0
-pytest-cov==6.1.1
-pytest-httpx==0.34.0
+pytest-cov==6.2.1
+pytest-httpx==0.35.0
 pytest-mock==3.14.1
 pytest==8.4.0
 PyYAML==6.0.2

--- a/requirements/requirements.dev.3.11.txt
+++ b/requirements/requirements.dev.3.11.txt
@@ -1,6 +1,6 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 cfgv==3.4.0
-coverage==7.8.2
+coverage==7.9.0
 distlib==0.3.9
 filelock==3.18.0
 identify==2.6.12
@@ -14,8 +14,8 @@ pluggy==1.6.0
 pre_commit==4.2.0
 Pygments==2.19.1
 pytest-asyncio==1.0.0
-pytest-cov==6.1.1
-pytest-httpx==0.34.0
+pytest-cov==6.2.1
+pytest-httpx==0.35.0
 pytest-mock==3.14.1
 pytest==8.4.0
 PyYAML==6.0.2

--- a/requirements/requirements.dev.3.12.txt
+++ b/requirements/requirements.dev.3.12.txt
@@ -1,6 +1,6 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 cfgv==3.4.0
-coverage==7.8.2
+coverage==7.9.0
 distlib==0.3.9
 filelock==3.18.0
 identify==2.6.12
@@ -14,8 +14,8 @@ pluggy==1.6.0
 pre_commit==4.2.0
 Pygments==2.19.1
 pytest-asyncio==1.0.0
-pytest-cov==6.1.1
-pytest-httpx==0.34.0
+pytest-cov==6.2.1
+pytest-httpx==0.35.0
 pytest-mock==3.14.1
 pytest==8.4.0
 PyYAML==6.0.2

--- a/requirements/requirements.dev.3.13.txt
+++ b/requirements/requirements.dev.3.13.txt
@@ -1,6 +1,6 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 cfgv==3.4.0
-coverage==7.8.2
+coverage==7.9.0
 distlib==0.3.9
 filelock==3.18.0
 identify==2.6.12
@@ -14,8 +14,8 @@ pluggy==1.6.0
 pre_commit==4.2.0
 Pygments==2.19.1
 pytest-asyncio==1.0.0
-pytest-cov==6.1.1
-pytest-httpx==0.34.0
+pytest-cov==6.2.1
+pytest-httpx==0.35.0
 pytest-mock==3.14.1
 pytest==8.4.0
 PyYAML==6.0.2

--- a/requirements/requirements.dev.3.9.txt
+++ b/requirements/requirements.dev.3.9.txt
@@ -1,6 +1,6 @@
-# -e git+https://github.com/waylayio/waylay-py-core.git@a15096c2e225bd36ae6c452f0b904dcf9cf64155#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
+# -e git+https://github.com/waylayio/waylay-py-core.git@5051d9b82ad6d0e93dfd411a8f5c36d81029536f#egg=waylay_sdk_plugin_example&subdirectory=test/plugin
 cfgv==3.4.0
-coverage==7.8.2
+coverage==7.9.0
 distlib==0.3.9
 filelock==3.18.0
 identify==2.6.12
@@ -14,8 +14,8 @@ pluggy==1.6.0
 pre_commit==4.2.0
 Pygments==2.19.1
 pytest-asyncio==1.0.0
-pytest-cov==6.1.1
-pytest-httpx==0.34.0
+pytest-cov==6.2.1
+pytest-httpx==0.35.0
 pytest-mock==3.14.1
 pytest==8.4.0
 PyYAML==6.0.2

--- a/src/waylay/sdk/api/http.py
+++ b/src/waylay/sdk/api/http.py
@@ -56,7 +56,6 @@ class HttpClientOptions(TypedDict, total=False):
     http1: bool
     http2: bool
     proxy: httpx_types.ProxyTypes
-    proxies: httpx_types.ProxiesTypes
     mounts: Mapping[str, httpx_types.AsyncBaseTransport | None]
     timeout: httpx_types.TimeoutTypes
     follow_redirects: bool
@@ -65,6 +64,5 @@ class HttpClientOptions(TypedDict, total=False):
     event_hooks: Mapping[str, list[Callable[..., Any]]]
     base_url: str
     transport: httpx_types.AsyncBaseTransport
-    app: Callable[..., Any]
     trust_env: bool
     default_encoding: str | Callable[[bytes], str]

--- a/src/waylay/sdk/api/httpx_types.py
+++ b/src/waylay/sdk/api/httpx_types.py
@@ -1,22 +1,23 @@
 """Types from the httpx library."""
 
+import ssl
 from typing import IO, List, Mapping, Optional, Sequence, Tuple, Union
 
 from httpx._client import (
     AsyncBaseTransport,
+    Limits,
+)
+from httpx._types import (
     AuthTypes,
     CertTypes,
     CookieTypes,
-    Limits,
-    ProxiesTypes,
     ProxyTypes,
     RequestData,
     RequestExtensions,
     RequestFiles,
     TimeoutTypes,
-    VerifyTypes,
 )
-from httpx._client import (
+from httpx._types import (
     RequestContent as _RequestContent,
 )
 
@@ -39,6 +40,7 @@ QueryParamTypes = Union[
     str,
     bytes,
 ]
+VerifyTypes = Union[ssl.SSLContext, str, bool]
 
 __all__ = [
     "RequestFiles",
@@ -51,7 +53,7 @@ __all__ = [
     "QueryParamTypes",
     "RequestExtensions",
     "VerifyTypes",
-    "ProxiesTypes",
+    "ProxyTypes",
     "AsyncBaseTransport",
     "Limits",
     "CertTypes",

--- a/test/unit/api/__snapshots__/api_client_test.ambr
+++ b/test/unit/api/__snapshots__/api_client_test.ambr
@@ -72,7 +72,7 @@
 # ---
 # name: test_deserialize[dict_with_self_model]
   tuple(
-    b'{"self": "me"}',
+    b'{"self":"me"}',
     200,
     dict({
       '*': Model,
@@ -107,7 +107,7 @@
 # ---
 # name: test_deserialize[json_dict0]
   tuple(
-    b'{"hello": "world", "key": [1, 2, 3]}',
+    b'{"hello":"world","key":[1,2,3]}',
     200,
     dict({
     }),
@@ -118,7 +118,7 @@
 # ---
 # name: test_deserialize[json_dict1]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
     }),
@@ -129,7 +129,7 @@
 # ---
 # name: test_deserialize[json_dict_*_dummy_union]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '*': <class 'unit.api.example.pet_model.Pet'>,
@@ -141,7 +141,7 @@
 # ---
 # name: test_deserialize[json_dict_*_union]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '*': typing.Union[unit.api.example.pet_model.PetList, unit.api.example.pet_model.Pet],
@@ -153,7 +153,7 @@
 # ---
 # name: test_deserialize[json_dict_2XX_dict]
   tuple(
-    b'{"message": "some not found message", "code": "RESOURCE_NOT_FOUND"}',
+    b'{"message":"some not found message","code":"RESOURCE_NOT_FOUND"}',
     201,
     dict({
       '2XX': typing.Dict[str, str],
@@ -168,7 +168,7 @@
 # ---
 # name: test_deserialize[json_dict_any]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': typing.Any,
@@ -187,7 +187,7 @@
 # ---
 # name: test_deserialize[json_dict_any_model]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': Model,
@@ -199,7 +199,7 @@
 # ---
 # name: test_deserialize[json_dict_default_dict]
   tuple(
-    b'{"message": "some not found message", "code": "RESOURCE_NOT_FOUND"}',
+    b'{"message":"some not found message","code":"RESOURCE_NOT_FOUND"}',
     201,
     dict({
       'default': <class 'dict'>,
@@ -214,7 +214,7 @@
 # ---
 # name: test_deserialize[json_dict_dict]
   tuple(
-    b'{"message": "some not found message", "code": "RESOURCE_NOT_FOUND"}',
+    b'{"message":"some not found message","code":"RESOURCE_NOT_FOUND"}',
     201,
     dict({
       '201': typing.Dict[str, str],
@@ -229,7 +229,7 @@
 # ---
 # name: test_deserialize[json_dict_model]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.Pet'>,
@@ -241,7 +241,7 @@
 # ---
 # name: test_deserialize[json_dict_model_any]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': typing.Any,
@@ -260,7 +260,7 @@
 # ---
 # name: test_deserialize[json_dict_model_with_alias_prop]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo", "pet_id": 1}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo","pet_id":1}',
     200,
     dict({
       '*': <class 'unit.api.example.pet_model.PetWithAlias'>,
@@ -272,7 +272,7 @@
 # ---
 # name: test_deserialize[json_dict_namespace]
   tuple(
-    b'{"message": "some not found message", "code": "RESOURCE_NOT_FOUND"}',
+    b'{"message":"some not found message","code":"RESOURCE_NOT_FOUND"}',
     201,
     dict({
       '2XX': <class 'types.SimpleNamespace'>,
@@ -284,7 +284,7 @@
 # ---
 # name: test_deserialize[json_dict_no_mapping]
   tuple(
-    b'{"message": "some not found message", "code": "RESOURCE_NOT_FOUND"}',
+    b'{"message":"some not found message","code":"RESOURCE_NOT_FOUND"}',
     201,
     dict({
       '4XX': typing.Dict[str, str],
@@ -296,7 +296,7 @@
 # ---
 # name: test_deserialize[json_dict_none]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': None,
@@ -308,7 +308,7 @@
 # ---
 # name: test_deserialize[json_dict_object]
   tuple(
-    b'{"hello": "world", "key": [1, 2, 3]}',
+    b'{"hello":"world","key":[1,2,3]}',
     200,
     dict({
       '200': <class 'object'>,
@@ -327,7 +327,7 @@
 # ---
 # name: test_deserialize[json_dict_str_path_name]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': <class 'str'>,
@@ -339,7 +339,7 @@
 # ---
 # name: test_deserialize[json_dict_union]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': typing.Union[str, list[unit.api.example.pet_model.Pet], unit.api.example.pet_model.Pet],
@@ -351,7 +351,7 @@
 # ---
 # name: test_deserialize[json_list]
   tuple(
-    b'["hello", "world", 123, {"key": "value"}]',
+    b'["hello","world",123,{"key":"value"}]',
     200,
     dict({
     }),
@@ -367,7 +367,7 @@
 # ---
 # name: test_deserialize[json_list_*_union]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '*': typing.Union[unit.api.example.pet_model.PetList, unit.api.example.pet_model.Pet],
@@ -379,7 +379,7 @@
 # ---
 # name: test_deserialize[json_list_XX_list_int]
   tuple(
-    b'["11", "22", 33]',
+    b'["11","22",33]',
     200,
     dict({
       '2XX': typing.List[int],
@@ -395,7 +395,7 @@
 # ---
 # name: test_deserialize[json_list_X_union]
   tuple(
-    b'["hello", "world", 123, {"key": "value"}]',
+    b'["hello","world",123,{"key":"value"}]',
     200,
     dict({
       '2XX': typing.List[typing.Union[str, int, typing.Dict[str, typing.Any]]],
@@ -414,7 +414,7 @@
 # ---
 # name: test_deserialize[json_list_any_model]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '*': Model,
@@ -426,7 +426,7 @@
 # ---
 # name: test_deserialize[json_list_any_model_path_pets]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': typing.List[Model],
@@ -441,7 +441,7 @@
 # ---
 # name: test_deserialize[json_list_list_path_[*].name]
   tuple(
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
     200,
     dict({
       '200': typing.List[ForwardRef('str')],
@@ -455,7 +455,7 @@
 # ---
 # name: test_deserialize[json_list_list_path_pets[*].name]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': typing.List[str],
@@ -470,7 +470,7 @@
 # ---
 # name: test_deserialize[json_list_list_path_pets[0].name]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': <class 'str'>,
@@ -482,7 +482,7 @@
 # ---
 # name: test_deserialize[json_list_list_path_pets[1:].name]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': typing.List[str],
@@ -496,7 +496,7 @@
 # ---
 # name: test_deserialize[json_list_model]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.PetList'>,
@@ -508,7 +508,7 @@
 # ---
 # name: test_deserialize[json_list_model_path_pets]
   tuple(
-    b'{"pets": [{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}, {"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}]}',
+    b'{"pets":[{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"},{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}]}',
     200,
     dict({
       '200': typing.List[unit.api.example.pet_model.Pet],
@@ -523,7 +523,7 @@
 # ---
 # name: test_deserialize[json_list_x_list]
   tuple(
-    b'["hello", "world", 123, {"key": "value"}]',
+    b'["hello","world",123,{"key":"value"}]',
     200,
     dict({
       '2XX': <class 'list'>,
@@ -542,7 +542,7 @@
 # ---
 # name: test_deserialize[json_model_invalid_field]
   tuple(
-    b'{"name": 111, "owner": {"id": 456, "name": "Simon"}}',
+    b'{"name":111,"owner":{"id":456,"name":"Simon"}}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.Pet'>,
@@ -554,7 +554,7 @@
 # ---
 # name: test_deserialize[json_model_invalid_submodel_field]
   tuple(
-    b'{"name": 111, "owner": {"id": "invalidId", "name": "Simon"}}',
+    b'{"name":111,"owner":{"id":"invalidId","name":"Simon"}}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.Pet'>,
@@ -566,7 +566,7 @@
 # ---
 # name: test_deserialize[json_model_invalid_submodel_list_field]
   tuple(
-    b'{"pets": [{"name": 111, "owner": {"id": "invalidId", "name": "Simon"}}, {"name": "Chop"}]}',
+    b'{"pets":[{"name":111,"owner":{"id":"invalidId","name":"Simon"}},{"name":"Chop"}]}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.PetList'>,
@@ -578,7 +578,7 @@
 # ---
 # name: test_deserialize[json_model_invalid_submodule_list]
   tuple(
-    b'[{"name": 111, "owner": {"id": "invalidId", "name": "Simon"}}, {"name": "Chop"}]',
+    b'[{"name":111,"owner":{"id":"invalidId","name":"Simon"}},{"name":"Chop"}]',
     200,
     dict({
       '200': typing.List[unit.api.example.pet_model.Pet],
@@ -593,7 +593,7 @@
 # ---
 # name: test_deserialize[json_model_missing_field]
   tuple(
-    b'{"owner": {"id": 456, "name": "Simontis"}}',
+    b'{"owner":{"id":456,"name":"Simontis"}}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.Pet'>,
@@ -605,7 +605,7 @@
 # ---
 # name: test_deserialize[json_model_missing_submodel_field]
   tuple(
-    b'{"name": "Chop"}',
+    b'{"name":"Chop"}',
     200,
     dict({
       '200': <class 'unit.api.example.pet_model.Pet'>,
@@ -809,8 +809,8 @@
       ApiError('Error response.')
       Status: 404
       Reason: Not Found
-      Response headers: Headers({'content-length': '67', 'content-type': 'application/json'})
-      Response content: <bytes: len=67>
+      Response headers: Headers({'content-length': '64', 'content-type': 'application/json'})
+      Response content: <bytes: len=64>
       Response data: {'message': 'some not found message', 'code': 'RESOURCE_NOT_FOUND'}
     ''',
     'dict',
@@ -826,8 +826,8 @@
       ApiError('Error response.')
       Status: 404
       Reason: Not Found
-      Response headers: Headers({'content-length': '67', 'content-type': 'application/json'})
-      Response content: <bytes: len=67>
+      Response headers: Headers({'content-length': '64', 'content-type': 'application/json'})
+      Response content: <bytes: len=64>
       Response data: {'message': 'some not found message', 'code': 'RESOURCE_NOT_FOUND'}
     ''',
     'dict',
@@ -843,8 +843,8 @@
       ApiError('Error response.')
       Status: 404
       Reason: Not Found
-      Response headers: Headers({'content-length': '67', 'content-type': 'application/json'})
-      Response content: <bytes: len=67>
+      Response headers: Headers({'content-length': '64', 'content-type': 'application/json'})
+      Response content: <bytes: len=64>
       Response data: {'message': 'some not found message', 'code': 'RESOURCE_NOT_FOUND'}
     ''',
     'dict',
@@ -874,8 +874,8 @@
       ApiError('Error response.')
       Status: 404
       Reason: Not Found
-      Response headers: Headers({'content-length': '67', 'content-type': 'application/json'})
-      Response content: <bytes: len=67>
+      Response headers: Headers({'content-length': '64', 'content-type': 'application/json'})
+      Response content: <bytes: len=64>
       Response data: message='some not found message' code='RESOURCE_NOT_FOUND'
     ''',
     '_Model',
@@ -888,8 +888,8 @@
       ApiError('Error response.')
       Status: 400
       Reason: Bad Request
-      Response headers: Headers({'content-length': '95', 'content-type': 'application/json'})
-      Response content: <bytes: len=95>
+      Response headers: Headers({'content-length': '87', 'content-type': 'application/json'})
+      Response content: <bytes: len=87>
       Response data: name='Lord Biscuit, Master of Naps' owner=PetOwner(id=123, name='Simon') tag='doggo'
     ''',
     'Pet',
@@ -923,8 +923,8 @@
       ApiError('Error response.')
       Status: 400
       Reason: Bad Request
-      Response headers: Headers({'content-length': '95', 'content-type': 'application/json'})
-      Response content: <bytes: len=95>
+      Response headers: Headers({'content-length': '87', 'content-type': 'application/json'})
+      Response content: <bytes: len=87>
       Response data: name='Lord Biscuit, Master of Naps' owner=_Model(id=123, name='Simon') tag='doggo'
     ''',
     '_Model',
@@ -1163,18 +1163,18 @@
         }),
       }),
       'method': 'PATCH',
-      'url': URL('https://api-example.io/service/v1/A/bar/{missing_param}'),
+      'url': URL('https://api-example.io/service/v1/A/bar/%7Bmissing_param%7D'),
     }),
     dict({
       'accept': '*/*',
       'accept-encoding': 'gzip, deflate',
       'connection': 'keep-alive',
-      'content-length': '119',
+      'content-length': '109',
       'content-type': 'application/json',
       'host': 'api-example.io',
       'x-my-header': 'header_value',
     }),
-    b'{"array_key": ["val1", "val2"], "tuple_key": ["val3", 123, {"key": "value"}, null], "timestamp": "1999-09-28T12:30:59"}',
+    b'{"array_key":["val1","val2"],"tuple_key":["val3",123,{"key":"value"},null],"timestamp":"1999-09-28T12:30:59"}',
   )
 # ---
 # name: test_serialize_and_call[path_and_query_params]
@@ -1219,11 +1219,11 @@
       'accept': '*/*',
       'accept-encoding': 'gzip, deflate',
       'connection': 'keep-alive',
-      'content-length': '95',
+      'content-length': '87',
       'content-type': 'application/json',
       'host': 'api-example.io',
     }),
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
   )
 # ---
 # name: test_serialize_and_call[pet_dict_body]
@@ -1244,11 +1244,11 @@
       'accept': '*/*',
       'accept-encoding': 'gzip, deflate',
       'connection': 'keep-alive',
-      'content-length': '95',
+      'content-length': '87',
       'content-type': 'application/json',
       'host': 'api-example.io',
     }),
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo"}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo"}',
   )
 # ---
 # name: test_serialize_and_call[pet_json_body]
@@ -1288,16 +1288,16 @@
         }),
       }),
       'method': 'PUT',
-      'url': URL('https://api-example.io/service/v1/{param1}/foo'),
+      'url': URL('https://api-example.io/service/v1/%7Bparam1%7D/foo'),
     }),
     dict({
       'accept': '*/*',
       'accept-encoding': 'gzip, deflate',
       'connection': 'keep-alive',
-      'content-length': '108',
+      'content-length': '98',
       'content-type': 'application/json',
       'host': 'api-example.io',
     }),
-    b'{"name": "Lord Biscuit, Master of Naps", "owner": {"id": 123, "name": "Simon"}, "tag": "doggo", "pet_id": 1}',
+    b'{"name":"Lord Biscuit, Master of Naps","owner":{"id":123,"name":"Simon"},"tag":"doggo","pet_id":1}',
   )
 # ---

--- a/test/unit/context_mgmt_test.py
+++ b/test/unit/context_mgmt_test.py
@@ -123,7 +123,7 @@ async def test_async_request(my_client: WaylayClient):
         buff = buff + chunck
         chuncks += 1
     assert chuncks == 2
-    assert response.num_bytes_downloaded == 20
+    assert response.num_bytes_downloaded == 19
     assert json.loads(buff) == {"message": "hello"}
 
 


### PR DESCRIPTION
* remove the httpx dependency restriction, that was imposed by a a problem `pytest-httpx` (resolved in 0.35.0)
* has some minor api breaks in the `HttpClientOptions` coming from similar api changes in httpx:
  * `proxies` is no longer supported in httpx, use `proxy`
  * `app` is no longer supported, use `transport=httpx.ASGITransport(app=app)` instead
* the json serialisation in httpx seems to have removed unnecessary whitespace, for which the test suite snapshots have been updated.